### PR TITLE
Fix broken Docker env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ COPY ./package.json $NYKK_ROOT
 COPY ./package-lock.json $NYKK_ROOT
 
 RUN npm --version && \
-    npm install
+    npm install && \
+    npm ls

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: .
       dockerfile: ./Dockerfile
     volumes:
-      - ./:/usr/src/nykk-btn
+      - .:/usr/src/nykk-btn
+      - /usr/src/nykk-btn/node_modules
     working_dir: /usr/src/nykk-btn
     entrypoint: npm


### PR DESCRIPTION
Docker 環境で build 時の `npm install` が `docker-compose run npm ...` 時に反映されていなかった問題を修正する。
Ref: https://postd.cc/lessons-building-node-app-docker/