### PR TITLE
Add eslint-ejs plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,9 @@
   "parserOptions": {
     "sourceType": "module"
   },
+  "plugins": [
+    "ejs-js"
+  ],
   "rules": {
     "comma-spacing": ["error", { "before": false, "after": true }],
     "curly": ["error", "all"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -263,6 +263,12 @@
         "text-table": "^0.2.0"
       }
     },
+    "eslint-plugin-ejs-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ejs-js/-/eslint-plugin-ejs-js-0.1.0.tgz",
+      "integrity": "sha512-hMeS+JFv1B8mJrhelXQ53xOueC/VlR4xu4tj1fmk2TO9bg4EzlJmubop+7zafhW9X8LSauQsFFAI0BsqTLHF2Q==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "ejs": "^2.6.1",
     "eslint": "^5.8.0",
+    "eslint-plugin-ejs-js": "^0.1.0",
     "prettier": "^1.14.3"
   }
 }


### PR DESCRIPTION
ejs 用の ESLint Plugin を追加する。
Prettier は ejs 未対応のようで悲しい。